### PR TITLE
Added automatic re-indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This hotkey lets you:
     - Places your cursor so you can fill in the details quickly
 - Jump from your footnote TO the footnote detail
 - Jump from your footnote detail BACK to the footnote 
+- New in January 2022: Automatic re-indexing of footnotes
 
 ![Overview](https://github.com/akaalias/obsidian-footnotes/blob/master/basic.gif?raw=true)
 
@@ -36,6 +37,9 @@ I personally use <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>6</kbd> because "6" on
 - And a new footnote details marker (e.g. `[^2]: `) is inserted on the last line of the document
 - And my cursor is now placed at the end of the detail marker (e.g. `[^2]: ▊`)
 
+### Scenario: Footnote is inserted in between existing footnotes
+- All existing footnotes get updated and the new one inserted as in the previous Scenarios
+
 ### Scenario: Jumping TO a footnote detail
 - Given I'm on a footnote detail line (e.g. `[^1]: ▊`)
 - When I hit `my footnote hotkey`
@@ -47,93 +51,8 @@ I personally use <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>6</kbd> because "6" on
 - Then my cursor is placed to the right of the footnote (e.g. `[^1]: ▊`)
 
 ### Known Limitations or Untested Scenarios
-#### Indices are not updated
-Inserting new footnote in-between two existing footnotes will insert the next numeric index (e.g. `1, 3, 2`). 
-
-It will NOT update the indices according to their natural order (e.g. `1, 2, 3`). 
-
-```markdown
-Example sentence[^1] with two▊ footnotes[^2] already.
-  
-[^1]: Foo
-[^2]: Bar
-```
-
-After insertion:
-
-```markdown
-Example sentence[^1] with two[^3] footnotes[^2] already.
-  
-[^1]: Foo
-[^2]: Bar
-[^3]: Baz
-```
-
-See "Automatically Re-Index Footnotes" below for a proposed feature
-
-## Future Possible Feature Ideas
-### Automatically Re-Index Footnotes
-Re-index and re-sort all footnotes when you insert a new one in-between one or more existing numbered footnotes:
-
-```markdown
-Example sentence[^1] with two▊ footnotes[^2] already.
-  
-[^1]: Foo
-[^2]: Bar
-```
-#### Base Scenario
-- Given there are two footnotes already
-- When I enter a new footnote in-between those two
-- Then the NEW footnote gets the index "2" 
-- And the previously second footnote gets the index "3"
-- And the NEW footnote detail is inserted as the second entry at the bottom
-- And the previously second footnote detail at the bottom is updated to be "3"
-- And the previously second footnote detail at the bottom is updated to be in third position
-
-```markdown
-Example sentence[^1] with two[^2] footnotes[^3] already.
-
-[^1]: Foo
-[^2]: Baz
-[^3]: Bar▊
-```
-
-#### Edge Cases to consider ("What if...?")
-##### What if... new footnote is inserted before the first footnote?
-  ```markdown
-  Some sentence▊ with existing note[^1]
-  
-  [^1]: Details
-  ```
-##### What if... text has the same footnote at several places?
-  ```markdown
-  Some sentence with existing note[^1] and the same▊ footnote re-appears later[^1].
-
-  
-  [^1]: Details
-  ```
-##### What if...Footnote details are spread across the text?
-  ```markdown
-  Some sentence with existing note[^1] some more text▊ 
-  
-  [^1]: Inline footnote details
-  
-  Another text part▊
-  ```
-##### What if... the footnote details are multi-line on the bottom?
-  ```markdown
-  Some sentence with existing note[^1] some more text▊ 
-  
-  [^1]: The details that
-  Span across
-  Multiple lines
-  ```
-##### What if... there are non-numeric footnotes in the text?
-  ```markdown
-  Some sentence with existing note[^✝] some more text▊ 
-  
-  [^✝]: Details
-  ```
+#### Manually Deleting Footnotes or Copy-Pasting Text Chunks
+Because the plugin only gets triggered when it is manually invoked for example by pressing the hotkey, this is an unsolved issue.
 
 ## Background
 This plugin is based on the great idea by [jacob.4ristotle](https://forum.obsidian.md/u/jacob.4ristotle/summary) posted in the ["Footnote Shortcut"](https://forum.obsidian.md/t/footnote-shortcut/8872) thread.


### PR DESCRIPTION
I added functionality for re-indexing footnotes automatically.

To achieve this I mostly re-wrote the `shouldCreateNewFootnote()` function.
The new footnote ID is determined by just searching for the biggest footnote before the current cursor position.
Then all IDs bigger or equal to that get incremented.
Lastly the new footnote marker and detail get added.

Regarding the edge cases:

> What if... new footnote is inserted before the first footnote?

Footnote details get added before the next one. So not an issue.

> What if... text has the same footnote at several places?

Not an issue since only bigger IDs ever get incremented. New footnote is only added afterwards.

> What if...Footnote details are spread across the text?

Not an issue since the correct position is just searched for everywhere after the cursor (could be changed to everywhere maybe?)

> What if... the footnote details are multi-line on the bottom?

Not an issue as the new detail line is placed just before the next one.

> What if... there are non-numeric footnotes in the text?

Get ignored for now.